### PR TITLE
add Nathan anniversary

### DIFF
--- a/src/data/birthdays.json
+++ b/src/data/birthdays.json
@@ -11,5 +11,6 @@
   { "year":1988, "month": 4, "day": 3, "who": "Eric Moore" },
   { "year":1975, "month":11, "day":20, "who": "Gareth Liddiard (Tropical Fuck Storm)" },
   { "year":1924, "month": 5, "day":15, "who": "Amby's Gran" },
+  { "year":2024, "month": 5, "day":20, "who": "Nathan (the synth table)" },
   {}
 ]


### PR DESCRIPTION
[5/20/2024](https://kglw.net/setlists/king-gizzard-the-lizard-wizard-may-20-2024-columbiahalle-berlin-germany.html)